### PR TITLE
fix: 国际化跳转链接错误bug

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -28,8 +28,8 @@ export default defineConfig({
       label: "English (Great Britain)",
       lang: "en-GB"
     },
-    zh: {
-      label: "Chinese | 中文",
+    "zh-CN": {
+      label: "Chinese (Simplified) | 简体中文",
       lang: "zh-CN",
       link: "/zh-CN"
     }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -31,7 +31,7 @@ export default defineConfig({
     zh: {
       label: "Chinese | 中文",
       lang: "zh-CN",
-      link: "/zh-CN/index"
+      link: "/zh-CN"
     }
   }
 })


### PR DESCRIPTION
@zihluwang 
修复 从 /api-examples.html 切中文时 URI 会变成 /zh-CN/index/api-examples.html [#1 ](url)